### PR TITLE
fix: add `transformPageData` hook so dynamic pages get the correct <title>

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -49,4 +49,15 @@ export default defineConfig({
       },
     ],
   },
+  /** Give each dynamic page its own <title> */
+  transformPageData(pageData) {
+    // params returned from [*].paths.js|ts are available here
+    const pageTitle = pageData.params?.pageTitle;
+
+    if (pageTitle) {
+      pageData.title = pageTitle;
+      pageData.frontmatter ??= {};
+      pageData.frontmatter.title = pageTitle;
+    }
+  },
 });


### PR DESCRIPTION
This PR adds a `transformPageData` hook in `.vitepress/config.ts` that promotes the `pageTitle` param returned by the paths loaders (`[*].paths.js`) to these places:

* `pageData.title` – `pageTitle` becomes the document `<title>`
* `pageData.frontmatter.title` – to keep theme in sync

### Before:

Browser tab always showed default title for dynamic pages:

<img width="758" height="523" alt="2025-07-28--19-13-47--131" src="https://github.com/user-attachments/assets/2fc8741c-0ad3-42d6-b565-ae013aca2e8c" />

### After:

Browser tab shows page title returned by `[*].paths.js`, matching each `operationId` or tag.

<img width="758" height="523" alt="2025-07-28--19-14-02--899" src="https://github.com/user-attachments/assets/bb3cbdd7-bb6d-4026-bef1-87fa422cb577" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentación**
  * Ahora cada página dinámica muestra un título HTML único basado en sus parámetros, mejorando la personalización de los títulos de página.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->